### PR TITLE
feature: production deploy 時に hosting 以外デプロイしないように

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ deploy:
   - provider: firebase
     skip_cleanup: true
     project: "hackforplay-production"
+    only: "hosting"
     token:
       secure: "WWIAdkpPKJyokculnpX9pQX8vZlZsjOmqrvg8w56J9fKOeeKt1vWzteZI2+gq1MLvHcd+S3USld9bxPy2lKJiFvgOfdKwohHwF1AELR3ISuuc63dx2T2mciaJTMTImGgG90/yqtmOBwd963SqD6jvf5J4JHZ36yUFg4zJ9Ik0YZIx0R1HkNJKNNVfvW11lCr3YBvajrUP+32npya67L2IRopEf8YLoknIW2TdVUfBJH3kZ+3i3upzY4xNKPUORBDdAGUOQCq9mtTq9zifm+OCRbfUg896vzXkTGAhmJravZ152QkDgBBlK7/3RdzZTYcsh/kBm+AbjC/cYE6FzZqk78Azpq27C1Wr3AWOcVjpZQFcMq0pmZZksmlu/nEfEuDiTQIH458emEdgS63Ba/dmtD9lj5bTA92DQ9F3Ep0VBPqLcABjLsFGzD/8VQ3kMB7TLdBapfkPgo7n2VRkKOQsjVku5En9Hwe5mukVuZByo05ILWhY1hnY2La2QCd+fP4MEMyBxANsBN27e0DFTf5pvagP7OLTkGdjW5Trenlm6FIEiyse33OJ2sDF9hPNKuvFFHzTTtoF8HikUW+AW4EnQRK3h6MCVahSi8lT/r+cdYrMF5/Vwt92p6rnU79VExS0a3JE0xtZCHydDaofwBucyuzBHpwc4UZ5JDcjE9STUI="
     on:


### PR DESCRIPTION
ある branch を master に merge push したら earlybird の設定がおかしくなった
原因は firebase deploy コマンドによって Firestore の設定が更新されたこと
firestore.rules ファイルはまだ master に merge されていなかったので、デプロイによって設定が元に戻ってしまった

# 対策

自動デプロイは hosting だけに限定する
それ以外の設定は **手動でデプロイ** する
production と earlybird は Firestore や Cloud Function を共有しているので気をつけなければならない