### PR TITLE
functions でない方の node_modules で tsc がコンパイルエラーを吐く問題を修正

### DIFF
--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -5,10 +5,9 @@
     "noImplicitReturns": true,
     "outDir": "lib",
     "sourceMap": true,
-    "target": "es6"
+    "target": "es6",
+    "typeRoots": ["./node_modules/@types"]
   },
   "compileOnSave": true,
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/functions/tslint.json
+++ b/functions/tslint.json
@@ -72,7 +72,7 @@
     "no-void-expression": [true, "ignore-arrow-function-shorthand"],
 
     // Makes sure result of typeof is compared to correct string values.
-    "typeof-compare": true,
+    "typeof-compare": false,
 
     // Disallow duplicate imports in the same file.
     "no-duplicate-imports": true,


### PR DESCRIPTION
この問題について

portal は現在 javascript+flow を使っている
functions だけ typescript を使ってみている
リポジトリが同じな方が何かと便利なので、ディレクトリで分けている
`/functions` で `tsc` すると落ちる

> ../node_modules/@types/react-dom/index.d.ts:19:72 - error TS2304: Cannot find name 'Text'.
>
> 19 export function findDOMNode(instance: ReactInstance): Element | null | Text;
>                                                                           ~~~~

そこ全然関係ないじゃん！！１

tsconfig の設定を見直す