### PR TITLE
fix: 保存した時にレンダリングに失敗する問題

### DIFF
--- a/src/components/PCRanking.jsx
+++ b/src/components/PCRanking.jsx
@@ -2,13 +2,11 @@
 import * as React from 'react';
 import moment from 'moment';
 import { Link } from 'react-router-dom';
-import Table from '@material-ui/core/Table/Table';
-import {
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow
-} from '@material-ui/core/Table';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 import Button from '@material-ui/core/Button';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -139,8 +137,8 @@ export default withTheme()((props: Props) => {
           まだ記録がないか、無効なステージです :-(
         </Typography>
       ) : (
-        <CircularProgress className={dcn.progress} />
-      )}
+            <CircularProgress className={dcn.progress} />
+          )}
       <Button
         variant="contained"
         color="primary"

--- a/src/components/ThumbnailDialog.jsx
+++ b/src/components/ThumbnailDialog.jsx
@@ -1,7 +1,9 @@
 // @flow
 import * as React from 'react';
-import Dialog from '@material-ui/core/Dialog/Dialog';
-import { DialogTitle, DialogContent, DialogActions } from '@material-ui/core/Dialog';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
 import Button from '@material-ui/core/Button';
 import { style, classes } from 'typestyle';
 


### PR DESCRIPTION
`Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined.`

import のパスを間違えている時に起こるバグ
`material-ui/Table/TableXX` が `@material-ui/core/TableXX` に変わったことで起きた
